### PR TITLE
Fix: raise if are missing env vars

### DIFF
--- a/lib/keycloak/token.ex
+++ b/lib/keycloak/token.ex
@@ -49,9 +49,9 @@ defmodule KeycloakAPI.Token do
   @spec get_env!(atom()) :: term()
   defp get_env!(key) do
     Application.fetch_env!(:keycloak_api, key) ||
-    raise """
-    environment variable <#{key}> is missing.
-    """
+      raise """
+      environment variable <#{key}> is missing.
+      """
   end
 
   defp handle_response({:ok, %{status: 200, body: body}}) do

--- a/lib/keycloak/token.ex
+++ b/lib/keycloak/token.ex
@@ -48,7 +48,10 @@ defmodule KeycloakAPI.Token do
   # Gets an env variable
   @spec get_env!(atom()) :: term()
   defp get_env!(key) do
-    Application.fetch_env!(:keycloak_api, key)
+    Application.fetch_env!(:keycloak_api, key) ||
+    raise """
+    environment variable <#{key}> is missing.
+    """
   end
 
   defp handle_response({:ok, %{status: 200, body: body}}) do

--- a/lib/keycloak/user.ex
+++ b/lib/keycloak/user.ex
@@ -105,9 +105,9 @@ defmodule KeycloakAPI.User do
   @spec get_env!(atom()) :: term()
   defp get_env!(key) do
     Application.fetch_env!(:keycloak_api, key) ||
-    raise """
-    environment variable <#{key}> is missing.
-    """
+      raise """
+      environment variable <#{key}> is missing.
+      """
   end
 
   defp handle_response({:ok, %{status: 201, headers: headers}}) do

--- a/lib/keycloak/user.ex
+++ b/lib/keycloak/user.ex
@@ -104,7 +104,10 @@ defmodule KeycloakAPI.User do
   # Gets an env variable
   @spec get_env!(atom()) :: term()
   defp get_env!(key) do
-    Application.fetch_env!(:keycloak_api, key)
+    Application.fetch_env!(:keycloak_api, key) ||
+    raise """
+    environment variable <#{key}> is missing.
+    """
   end
 
   defp handle_response({:ok, %{status: 201, headers: headers}}) do


### PR DESCRIPTION
## Changes
- Update the readme with a user creation example
- raise an error if some env var is nil